### PR TITLE
Strip viewer chrome for full-screen scene overlay

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -6,19 +6,13 @@
     <title>VisionJDR - Écran joueur</title>
     <link rel="stylesheet" href="/styles.css" />
   </head>
-  <body>
-    <main class="layout">
-      <header class="top-bar">
-        <h1>VisionJDR</h1>
-        <p class="top-bar__subtitle">En attente d'une scène…</p>
-      </header>
-      <section class="scene" id="scene">
-        <div class="scene__overlay">
-          <div class="scene__column scene__column--left" id="left-column"></div>
-          <div class="scene__column scene__column--right" id="right-column"></div>
-        </div>
-      </section>
-    </main>
+  <body class="viewer">
+    <section class="scene scene--player" id="scene">
+      <div class="scene__overlay">
+        <div class="scene__column scene__column--left" id="left-column"></div>
+        <div class="scene__column scene__column--right" id="right-column"></div>
+      </div>
+    </section>
 
     <script src="/socket.io/socket.io.js"></script>
     <script src="/viewer.js" type="module"></script>

--- a/public/styles.css
+++ b/public/styles.css
@@ -23,12 +23,24 @@ body {
   background: var(--bg-body);
   color: var(--text-primary);
   min-height: 100vh;
+  min-height: 100dvh;
+}
+
+body.viewer {
+  background: #000;
+  display: flex;
+  min-height: 100vh;
+  min-height: 100dvh;
 }
 
 main.layout {
+  min-height: 100vh;
+  min-height: 100dvh;
   display: grid;
-  gap: 2rem;
-  padding: 2.5rem clamp(1.5rem, 5vw, 4rem);
+  grid-template-rows: auto 1fr;
+  align-items: stretch;
+  gap: clamp(1.5rem, 3vw, 2.5rem);
+  padding: clamp(1.5rem, 4vw, 3rem);
 }
 
 .layout--admin {
@@ -76,11 +88,24 @@ main.layout {
 .scene {
   position: relative;
   border-radius: var(--radius-large);
-  min-height: clamp(420px, 65vh, 720px);
+  min-height: 0;
+  height: 100%;
   overflow: hidden;
   border: 1px solid rgba(255, 255, 255, 0.08);
   background: linear-gradient(160deg, #1e293b, #020617);
   box-shadow: var(--shadow-elevated);
+}
+
+.scene--player {
+  flex: 1;
+  border: none;
+  border-radius: 0;
+  box-shadow: none;
+  background: #000;
+}
+
+.scene--player .scene__overlay {
+  padding: 0;
 }
 
 .scene--preview {


### PR DESCRIPTION
## Summary
- remove the VisionJDR header and layout wrapper from the player page so only the scene overlay is rendered
- add viewer-specific styles that stretch the scene to the viewport and eliminate borders, padding, and shadows

## Testing
- npm start

------
https://chatgpt.com/codex/tasks/task_e_68de6a58f1488326b99d4a5b67455441