### PR TITLE
Fix player view height so scene renders

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -102,6 +102,8 @@ main.layout {
   border-radius: 0;
   box-shadow: none;
   background: #000;
+  min-height: 100vh;
+  min-height: 100dvh;
 }
 
 .scene--player .scene__overlay {


### PR DESCRIPTION
## Summary
- ensure the player scene section spans the full viewport height so its content is visible

## Testing
- Manual verification that the player page renders the background and character cards

------
https://chatgpt.com/codex/tasks/task_e_68de71e8967083269c333b06aca30e72