### PR TITLE
Adjust viewer character columns to 40% height

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -116,29 +116,37 @@ main.layout {
 
 .scene__overlay {
   position: absolute;
-  inset: 0;
+  inset: auto 0 0 0;
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 1.5rem;
   padding: clamp(1.5rem, 4vw, 3rem);
   backdrop-filter: blur(0.5px);
+  align-content: end;
+  align-items: end;
+  min-height: 40vh;
+  min-height: 40dvh;
+  max-height: 100%;
 }
 
 .scene__column {
   position: relative;
   display: flex;
   flex-direction: row;
-  align-items: center;
+  align-items: flex-end;
   justify-content: flex-start;
   gap: 0;
+  min-height: 40vh;
+  min-height: 40dvh;
+  height: 100%;
 }
 
 .scene__column--left {
-  align-items: center;
+  align-items: flex-end;
 }
 
 .scene__column--right {
-  align-items: center;
+  align-items: flex-end;
   justify-content: flex-end;
 }
 


### PR DESCRIPTION
## Summary
- lower the scene overlay minimum height to 40% of the viewport to match the new request
- ensure character columns inherit the 40% viewport-height requirement so cards start from the base

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68de8f3bc56883269723093826e970a4