### PR TITLE
Add support for multiple scene layouts in VisionJDR

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 # VisionJDR
 
-Une petite application temps-réel permettant à un administrateur de composer une scène "3 vs 2" et de l'afficher instantanément sur les écrans des joueurs connectés.
+Une petite application temps-réel permettant à un administrateur de composer différentes scènes asymétriques (de 1v0 jusqu'à 3v3) et de les afficher instantanément sur les écrans des joueurs connectés.
 
 ## Fonctionnalités
 
 - **Bibliothèque de décors et personnages** préconfigurée et extensible.
-- **Console administrateur** pour choisir un décor, 3 personnages à droite et 2 personnages à gauche.
+- **Console administrateur** pour choisir un décor, sélectionner une configuration (1v0, 0v1, 1v1, 2v1, 1v2, 2v2, 2v3, 1v3, 3v1, 3v2 ou 3v3)
+  puis affecter les personnages sur chaque colonne.
 - **Prévisualisation en direct** de la scène avant diffusion.
 - **Diffusion instantanée** de la scène à tous les clients joueurs via WebSocket.
 

--- a/public/admin.html
+++ b/public/admin.html
@@ -11,32 +11,34 @@
       <header class="top-bar">
         <div>
           <h1>VisionJDR – Console admin</h1>
-          <p class="top-bar__subtitle">Composer et diffuser des scènes 3v2 en direct</p>
+          <p class="top-bar__subtitle">Composer et diffuser des scènes personnalisées en direct</p>
         </div>
         <a class="top-bar__link" href="/" target="_blank" rel="noreferrer">Voir l'écran joueur</a>
       </header>
 
       <section class="admin-panel">
         <form id="scene-form" class="admin-form" autocomplete="off">
-          <h2>Scène 3v2</h2>
+          <h2>Scène personnalisée</h2>
 
           <div class="form-grid">
+            <label class="field">
+              <span class="field__label">Configuration</span>
+              <select id="layout" name="layout"></select>
+            </label>
+
             <label class="field">
               <span class="field__label">Décor</span>
               <select id="background" name="background"></select>
             </label>
 
-            <div class="field field--stack">
-              <span class="field__label">Personnages à gauche (2)</span>
-              <select id="left-0" name="left-0"></select>
-              <select id="left-1" name="left-1"></select>
+            <div class="field field--stack" id="field-left">
+              <span class="field__label" id="left-label">Personnages à gauche</span>
+              <div class="field__stack" id="left-selects"></div>
             </div>
 
-            <div class="field field--stack">
-              <span class="field__label">Personnages à droite (3)</span>
-              <select id="right-0" name="right-0"></select>
-              <select id="right-1" name="right-1"></select>
-              <select id="right-2" name="right-2"></select>
+            <div class="field field--stack" id="field-right">
+              <span class="field__label" id="right-label">Personnages à droite</span>
+              <div class="field__stack" id="right-selects"></div>
             </div>
           </div>
 

--- a/public/styles.css
+++ b/public/styles.css
@@ -261,8 +261,19 @@ main.layout {
   gap: 0.75rem;
 }
 
-.field--stack select {
-  margin-bottom: 0.5rem;
+.field__stack {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.field__stack select {
+  margin: 0;
+}
+
+.field__placeholder {
+  color: var(--text-muted);
+  font-style: italic;
+  font-size: 0.95rem;
 }
 
 .field__label {


### PR DESCRIPTION
## Summary
- add predefined scene layouts on the server and expose them through the API
- allow the admin console to select a layout and dynamically build the left/right character selectors
- refresh styling and documentation to reflect the new configurable scene formats

## Testing
- node server.js (then stopped with Ctrl+C)


------
https://chatgpt.com/codex/tasks/task_e_68df867039588326a8b485e9aa1df4dc