### PR TITLE
Support transparent PNG character art

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -246,6 +246,17 @@ main.layout {
   z-index: 1;
 }
 
+.character-card__image {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  pointer-events: none;
+  user-select: none;
+  z-index: 0;
+}
+
 .character-card--empty {
   border-style: dashed;
   color: rgba(226, 232, 240, 0.6);
@@ -269,6 +280,21 @@ main.layout {
   padding: 0.35rem 0.85rem;
   border-radius: 999px;
   box-shadow: 0 10px 25px rgba(15, 23, 42, 0.4);
+}
+
+.character-card--transparent {
+  background: none;
+  background-color: transparent;
+  border-color: rgba(255, 255, 255, 0.5);
+  box-shadow: 0 16px 36px rgba(15, 23, 42, 0.45);
+}
+
+.character-card--transparent::before {
+  display: none;
+}
+
+.character-card--transparent .character-card__label {
+  background: rgba(15, 23, 42, 0.75);
 }
 
 .admin-panel {

--- a/public/viewer.js
+++ b/public/viewer.js
@@ -87,23 +87,42 @@ const createCharacterCard = (characterId, position, column, index, totalCount) =
 
   wrapper.style.setProperty('--stack-translation', '0px');
 
+  const label = document.createElement('span');
+  label.className = 'character-card__label';
+
   if (!characterId) {
     wrapper.classList.add('character-card--empty');
-    wrapper.innerHTML = `<span class="character-card__label">Emplacement ${position}</span>`;
+    label.textContent = `Emplacement ${position}`;
+    wrapper.appendChild(label);
     return wrapper;
   }
 
   const character = charactersById[characterId];
   const characterName = character?.name ?? 'Inconnu';
 
+  label.textContent = characterName;
+
   if (character?.image) {
     wrapper.classList.add('character-card--with-image');
-    wrapper.style.background = `linear-gradient(180deg, rgba(15, 23, 42, 0.08), rgba(15, 23, 42, 0.82)), url("${character.image}") center / cover no-repeat`;
+
+    const imageElement = document.createElement('img');
+    imageElement.className = 'character-card__image';
+    imageElement.src = character.image;
+    imageElement.alt = characterName;
+    imageElement.loading = 'lazy';
+
+    wrapper.appendChild(imageElement);
+
+    const normalizedPath = (character.image ?? '').split('?')[0].toLowerCase();
+
+    if (normalizedPath.endsWith('.png')) {
+      wrapper.classList.add('character-card--transparent');
+    }
   } else {
     wrapper.style.background = character?.color ?? '#475569';
   }
 
-  wrapper.innerHTML = `<span class="character-card__label">${characterName}</span>`;
+  wrapper.appendChild(label);
 
   return wrapper;
 };


### PR DESCRIPTION
## Summary
- render character cards with image elements so we can detect transparent PNG assets
- add styling tweaks to remove dark overlays when a PNG should show the scene background

## Testing
- npm start

------
https://chatgpt.com/codex/tasks/task_e_68df9034177c8326bfabb1082b363bf3