### PR TITLE
Remove dark overlay from character cards

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -236,8 +236,8 @@ main.layout {
   content: '';
   position: absolute;
   inset: 0;
-  background: linear-gradient(180deg, rgba(255, 255, 255, 0.35), rgba(15, 23, 42, 0.75));
-  opacity: 0.6;
+  background: none;
+  opacity: 0;
 }
 
 .character-card span,
@@ -271,8 +271,8 @@ main.layout {
 }
 
 .character-card--with-image::before {
-  background: linear-gradient(180deg, rgba(15, 23, 42, 0.15), rgba(15, 23, 42, 0.8));
-  opacity: 0.85;
+  background: none;
+  opacity: 0;
 }
 
 .character-card--with-image .character-card__label {


### PR DESCRIPTION
## Summary
- remove the gradient overlay applied to character cards so the original artwork remains unobstructed

## Testing
- npm start

------
https://chatgpt.com/codex/tasks/task_e_68df91de0fdc832695646ec8a502a1ee