### PR TITLE
Retirer les bordures et les noms visibles des cartes personnages

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -220,7 +220,6 @@ main.layout {
   letter-spacing: 0.02em;
   position: relative;
   overflow: hidden;
-  border: 2px solid rgba(255, 255, 255, 0.35);
   box-shadow: 0 12px 30px rgba(15, 23, 42, 0.55);
   transition: transform var(--transition), box-shadow var(--transition);
   pointer-events: auto;
@@ -258,15 +257,15 @@ main.layout {
 }
 
 .character-card--empty {
-  border-style: dashed;
+  border: 2px dashed rgba(226, 232, 240, 0.35);
   color: rgba(226, 232, 240, 0.6);
   background: rgba(15, 23, 42, 0.5);
 }
 
 .character-card--with-image {
+  border: none;
   color: #f8fafc;
   background-color: #0f172a;
-  border-color: rgba(255, 255, 255, 0.6);
   box-shadow: 0 16px 36px rgba(15, 23, 42, 0.6);
 }
 
@@ -275,26 +274,20 @@ main.layout {
   opacity: 0;
 }
 
-.character-card--with-image .character-card__label {
-  background: rgba(15, 23, 42, 0.65);
-  padding: 0.35rem 0.85rem;
-  border-radius: 999px;
-  box-shadow: 0 10px 25px rgba(15, 23, 42, 0.4);
-}
-
 .character-card--transparent {
+  border: none;
   background: none;
   background-color: transparent;
-  border-color: rgba(255, 255, 255, 0.5);
   box-shadow: 0 16px 36px rgba(15, 23, 42, 0.45);
+}
+
+.character-card--with-image .character-card__label,
+.character-card--transparent .character-card__label {
+  display: none;
 }
 
 .character-card--transparent::before {
   display: none;
-}
-
-.character-card--transparent .character-card__label {
-  background: rgba(15, 23, 42, 0.75);
 }
 
 .admin-panel {

--- a/public/viewer.js
+++ b/public/viewer.js
@@ -87,10 +87,9 @@ const createCharacterCard = (characterId, position, column, index, totalCount) =
 
   wrapper.style.setProperty('--stack-translation', '0px');
 
-  const label = document.createElement('span');
-  label.className = 'character-card__label';
-
   if (!characterId) {
+    const label = document.createElement('span');
+    label.className = 'character-card__label';
     wrapper.classList.add('character-card--empty');
     label.textContent = `Emplacement ${position}`;
     wrapper.appendChild(label);
@@ -99,8 +98,7 @@ const createCharacterCard = (characterId, position, column, index, totalCount) =
 
   const character = charactersById[characterId];
   const characterName = character?.name ?? 'Inconnu';
-
-  label.textContent = characterName;
+  wrapper.setAttribute('aria-label', characterName);
 
   if (character?.image) {
     wrapper.classList.add('character-card--with-image');
@@ -121,8 +119,6 @@ const createCharacterCard = (characterId, position, column, index, totalCount) =
   } else {
     wrapper.style.background = character?.color ?? '#475569';
   }
-
-  wrapper.appendChild(label);
 
   return wrapper;
 };


### PR DESCRIPTION
## Summary
- supprime l'affichage du nom sur les cartes de personnages visibles tout en conservant les étiquettes pour les emplacements vides
- enlève la bordure appliquée aux cartes illustrées et conserve une bordure en pointillé pour les emplacements libres

## Testing
- npm start

------
https://chatgpt.com/codex/tasks/task_e_68df9327ba8c832690c14b4d7596f1db