### PR TITLE
Remove card chrome around character images

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -265,8 +265,9 @@ main.layout {
 .character-card--with-image {
   border: none;
   color: #f8fafc;
-  background-color: #0f172a;
-  box-shadow: 0 16px 36px rgba(15, 23, 42, 0.6);
+  background: none;
+  box-shadow: none;
+  padding: 0;
 }
 
 .character-card--with-image::before {
@@ -278,7 +279,7 @@ main.layout {
   border: none;
   background: none;
   background-color: transparent;
-  box-shadow: 0 16px 36px rgba(15, 23, 42, 0.45);
+  box-shadow: none;
 }
 
 .character-card--with-image .character-card__label,


### PR DESCRIPTION
## Summary
- remove the background, padding, and drop shadow from character cards that render an image so the artwork sits directly on the scene
- ensure transparent character cards also omit drop shadows to avoid any visible framing

## Testing
- npm start

------
https://chatgpt.com/codex/tasks/task_e_68df957a08b08326bfac2dd6a2245daf