### PR TITLE
Allow configuring character orientation

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -256,6 +256,11 @@ main.layout {
   z-index: 0;
 }
 
+.character-card__image--mirrored {
+  transform: scaleX(-1);
+  transform-origin: center;
+}
+
 .character-card--empty {
   border: 2px dashed rgba(226, 232, 240, 0.35);
   color: rgba(226, 232, 240, 0.6);
@@ -346,6 +351,34 @@ main.layout {
 
 .field__stack select {
   margin: 0;
+}
+
+.slot-controls {
+  display: grid;
+  gap: 0.5rem;
+}
+
+@media (min-width: 720px) {
+  .slot-controls {
+    grid-template-columns: minmax(0, 1fr) auto;
+    align-items: center;
+    gap: 0.75rem;
+  }
+}
+
+.slot-controls__orientation {
+  min-width: 10rem;
+  justify-self: start;
+}
+
+@media (min-width: 720px) {
+  .slot-controls__orientation {
+    justify-self: end;
+  }
+}
+
+.slot-controls__orientation--disabled {
+  opacity: 0.55;
 }
 
 .field__placeholder {

--- a/public/viewer.js
+++ b/public/viewer.js
@@ -75,7 +75,25 @@ const applyStackingSpacing = () => {
   updateStackingForColumn(rightColumn);
 };
 
-const createCharacterCard = (characterId, position, column, index, totalCount) => {
+const getSlotInfo = (slot) => {
+  if (!slot) {
+    return { id: null, orientation: 'normal' };
+  }
+
+  if (typeof slot === 'string') {
+    return { id: slot, orientation: 'normal' };
+  }
+
+  if (typeof slot === 'object') {
+    const id = slot.id ?? null;
+    const orientation = slot.orientation === 'mirrored' ? 'mirrored' : 'normal';
+    return { id, orientation };
+  }
+
+  return { id: null, orientation: 'normal' };
+};
+
+const createCharacterCard = (slot, position, column, index, totalCount) => {
   const wrapper = document.createElement('div');
   wrapper.className = 'character-card';
   wrapper.classList.add(`character-card--${column}`);
@@ -86,6 +104,8 @@ const createCharacterCard = (characterId, position, column, index, totalCount) =
   wrapper.style.zIndex = String(100 + overlayRank);
 
   wrapper.style.setProperty('--stack-translation', '0px');
+
+  const { id: characterId, orientation } = getSlotInfo(slot);
 
   if (!characterId) {
     const label = document.createElement('span');
@@ -108,6 +128,10 @@ const createCharacterCard = (characterId, position, column, index, totalCount) =
     imageElement.src = character.image;
     imageElement.alt = characterName;
     imageElement.loading = 'lazy';
+
+    if (orientation === 'mirrored') {
+      imageElement.classList.add('character-card__image--mirrored');
+    }
 
     wrapper.appendChild(imageElement);
 
@@ -136,11 +160,12 @@ const renderScene = (scene) => {
   leftColumn.replaceChildren();
   rightColumn.replaceChildren();
 
-  const leftCount = scene.left.length;
-  scene.left.forEach((characterId, index) => {
+  const leftSlots = Array.isArray(scene.left) ? scene.left : [];
+  const leftCount = leftSlots.length;
+  leftSlots.forEach((slot, index) => {
     leftColumn.appendChild(
       createCharacterCard(
-        characterId,
+        slot,
         `gauche ${index + 1}`,
         'left',
         index,
@@ -149,11 +174,12 @@ const renderScene = (scene) => {
     );
   });
 
-  const rightCount = scene.right.length;
-  scene.right.forEach((characterId, index) => {
+  const rightSlots = Array.isArray(scene.right) ? scene.right : [];
+  const rightCount = rightSlots.length;
+  rightSlots.forEach((slot, index) => {
     rightColumn.appendChild(
       createCharacterCard(
-        characterId,
+        slot,
         `droite ${index + 1}`,
         'right',
         index,


### PR DESCRIPTION
## Summary
- add orientation controls for each character slot in the admin console and preview
- propagate the selected orientation through the scene payload and viewer rendering
- style mirrored portraits and admin controls for the new orientation picker

## Testing
- npm install
- npm start

------
https://chatgpt.com/codex/tasks/task_e_68df96cb8b0883269f8b03633d46f788