### PR TITLE
Allow deleting uploaded media from admin library

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -581,6 +581,41 @@ select:focus {
   font-size: 0.85rem;
 }
 
+.asset-card__actions {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: auto;
+}
+
+.asset-card__button {
+  appearance: none;
+  border: 1px solid rgba(248, 113, 113, 0.45);
+  background: rgba(248, 113, 113, 0.12);
+  color: #fca5a5;
+  border-radius: var(--radius-small);
+  padding: 0.45rem 0.9rem;
+  font-size: 0.9rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform var(--transition), box-shadow var(--transition),
+    background var(--transition), border-color var(--transition);
+  box-shadow: 0 12px 24px rgba(248, 113, 113, 0.15);
+}
+
+.asset-card__button:hover {
+  transform: translateY(-1px);
+  background: rgba(248, 113, 113, 0.2);
+  border-color: rgba(248, 113, 113, 0.6);
+  box-shadow: 0 16px 32px rgba(248, 113, 113, 0.2);
+}
+
+.asset-card__button:disabled {
+  opacity: 0.7;
+  cursor: progress;
+  transform: none;
+  box-shadow: none;
+}
+
 .preview {
   background: var(--bg-panel-strong);
   border: 1px solid var(--border-soft);


### PR DESCRIPTION
## Summary
- add reusable helpers and HTTP DELETE endpoints to remove uploaded characters and backgrounds while cleaning up files
- extend the admin media page to trigger deletions with confirmation and status feedback
- style asset cards with dedicated delete controls for uploaded media

## Testing
- node server.js

------
https://chatgpt.com/codex/tasks/task_e_68df9d54c6988326a9a3d366a1587a06