### PR TITLE
Fix audio playback edge cases and streamline playlist controls

### DIFF
--- a/public/admin.js
+++ b/public/admin.js
@@ -924,10 +924,9 @@ const syncCombinedAudioMix = ({ emit = true } = {}) => {
 };
 
 const createPlaylistMixFromDefinition = (playlist) => {
-  const playlistTracks = Array.isArray(playlist?.trackIds) ? playlist.trackIds : [];
+  const playlistTracks = getPlayableTrackIdsFromPlaylist(playlist);
 
   const tracks = playlistTracks
-    .filter((trackId) => audioTracksById[trackId])
     .map((trackId) => ({ id: trackId, volume: 1, loop: false, playing: false, position: 0 }));
 
   return { tracks };
@@ -1046,6 +1045,11 @@ const formatPositionValue = (value) => {
   }
 
   return String(Math.round(value * 100) / 100);
+};
+
+const getPlayableTrackIdsFromPlaylist = (playlist) => {
+  const playlistTracks = Array.isArray(playlist?.trackIds) ? playlist.trackIds : [];
+  return playlistTracks.filter((trackId) => Boolean(audioTracksById[trackId]));
 };
 
 const advancePlaylistTrack = (finishedTrackId) => {
@@ -1512,7 +1516,6 @@ function updatePlaylistControlsAvailability() {
     return;
   }
 
-  const hasPlaylists = playlists.length > 0;
   const hasSelectedPlaylist = Boolean(selectedPlaylistId && playlistsById[selectedPlaylistId]);
   const hasMixTracks =
     Array.isArray(playlistPlaybackMix?.tracks) && playlistPlaybackMix.tracks.length > 0;
@@ -1526,7 +1529,7 @@ function updatePlaylistControlsAvailability() {
   playlistStartButton.disabled = !hasSelectedPlaylist;
   playlistStartRandomButton.disabled = !hasSelectedPlaylist;
   playlistStopButton.disabled = !hasMixTracks;
-  playlistCycleInput.disabled = !hasSelectedPlaylist && !hasMixTracks && !hasPlaylists;
+  playlistCycleInput.disabled = !hasSelectedPlaylist && !hasMixTracks;
   if (playlistTrackAddButton) {
     playlistTrackAddButton.disabled = !hasSelectedPlaylist || !hasPlaylistTrackSelection;
   }
@@ -1967,19 +1970,18 @@ const startSelectedPlaylistPlayback = ({ random = false } = {}) => {
     return;
   }
 
-  const nextPlaylistMix = createPlaylistMixFromDefinition(selectedPlaylist);
-  playlistPlaybackMix = cloneAudioMix(nextPlaylistMix);
-  activePlaylistId = selectedPlaylist.id;
-  syncCombinedAudioMix();
-
-  const tracks = Array.isArray(playlistPlaybackMix?.tracks) ? playlistPlaybackMix.tracks : [];
-  const playableTrackIds = tracks.map((track) => track.id).filter((id) => audioTracksById[id]);
+  const playableTrackIds = getPlayableTrackIdsFromPlaylist(selectedPlaylist);
 
   if (!playableTrackIds.length) {
     statusElement.textContent = 'Chargez une playlist avant de lancer la lecture.';
     updatePlaylistControlsAvailability();
     return;
   }
+
+  const nextPlaylistMix = createPlaylistMixFromDefinition(selectedPlaylist);
+  playlistPlaybackMix = cloneAudioMix(nextPlaylistMix);
+  activePlaylistId = selectedPlaylist.id;
+  syncCombinedAudioMix();
 
   activePlaylistTrackOrder = random ? shuffleTrackIds(playableTrackIds) : [...playableTrackIds];
   const firstTrackId = activePlaylistTrackOrder[0];
@@ -2038,6 +2040,9 @@ const deleteSelectedPlaylist = async () => {
 
   if (activePlaylistId === playlist.id) {
     activePlaylistId = null;
+    activePlaylistTrackOrder = [];
+    playlistPlaybackMix = { tracks: [] };
+    syncCombinedAudioMix();
   }
 
   statusElement.textContent = `Playlist « ${playlist.name} » supprimée.`;

--- a/public/viewer.js
+++ b/public/viewer.js
@@ -131,7 +131,8 @@ const createAudioPlayer = (source) => {
     source,
     pendingSeek: null,
     lastPosition: undefined,
-    desiredVolume: 1
+    desiredVolume: 1,
+    desiredPlaying: true
   };
 
   audioElement.addEventListener('loadedmetadata', () => {
@@ -167,10 +168,12 @@ const ensureAudioPlayer = (id, source) => {
   if (player.source !== source) {
     player.audio.pause();
     player.audio.src = source;
+    player.audio.load();
     player.source = source;
     player.pendingSeek = null;
     player.lastPosition = undefined;
     player.desiredVolume = 1;
+    player.desiredPlaying = true;
 
     try {
       player.audio.currentTime = 0;
@@ -245,6 +248,10 @@ const unlockAudioPlayback = () => {
 
   players.forEach((player) => {
     const { audio, desiredVolume } = player;
+
+    if (player.desiredPlaying === false) {
+      return;
+    }
 
     try {
       audio.muted = false;
@@ -678,6 +685,7 @@ const applyAudioMix = (mix) => {
     }
 
     const shouldPlay = track.playing === false ? false : true;
+    player.desiredPlaying = shouldPlay;
 
     if (shouldPlay) {
       audio.muted = false;
@@ -776,32 +784,38 @@ const handleLibraryUpdate = (library) => {
 };
 
 const initialise = async () => {
-  const [libraryResponse, sceneResponse, audioResponse] = await Promise.all([
-    fetch('/api/library'),
-    fetch('/api/scene'),
-    fetch('/api/audio')
-  ]);
+  try {
+    const [libraryResponse, sceneResponse, audioResponse] = await Promise.all([
+      fetch('/api/library'),
+      fetch('/api/scene'),
+      fetch('/api/audio')
+    ]);
 
-  if (!libraryResponse.ok || !sceneResponse.ok || !audioResponse.ok) {
+    if (!libraryResponse.ok || !sceneResponse.ok || !audioResponse.ok) {
+      if (subtitleElement) {
+        subtitleElement.textContent = 'Impossible de charger les scènes';
+      }
+      return;
+    }
+
+    const library = await libraryResponse.json();
+    const sceneData = await sceneResponse.json();
+    const audioData = await audioResponse.json();
+
+    handleLibraryUpdate(library);
+
+    renderScene(sceneData.scene);
+    applyAudioMix(audioData.mix);
+
+    const socket = io();
+    socket.on('scene:update', renderScene);
+    socket.on('library:update', handleLibraryUpdate);
+    socket.on('audio:update', applyAudioMix);
+  } catch (error) {
     if (subtitleElement) {
       subtitleElement.textContent = 'Impossible de charger les scènes';
     }
-    return;
   }
-
-  const library = await libraryResponse.json();
-  const sceneData = await sceneResponse.json();
-  const audioData = await audioResponse.json();
-
-  handleLibraryUpdate(library);
-
-  renderScene(sceneData.scene);
-  applyAudioMix(audioData.mix);
-
-  const socket = io();
-  socket.on('scene:update', renderScene);
-  socket.on('library:update', handleLibraryUpdate);
-  socket.on('audio:update', applyAudioMix);
 };
 
 initialise();


### PR DESCRIPTION
### Motivation
- Prevent unexpected audio resuming on viewer unlock by only restarting tracks that are intended to play. 
- Make audio source switching more robust across browsers when tracks change quickly. 
- Avoid unhandled failures in viewer startup when network or API calls fail. 
- Reduce inconsistent playlist activation states and simplify playlist handling in the admin UI.

### Description
- Viewer: add `desiredPlaying` to player state and set it when applying mixes so `unlockAudioPlayback` only resumes players whose `desiredPlaying` is `true`. 
- Viewer: call `player.audio.load()` when changing a player source to ensure element is reset reliably. 
- Viewer: wrap the initial `fetch('/api/library')`, `/api/scene`, `/api/audio` bootstrap in a `try/catch` and show the subtitles error message on failure to avoid uncaught errors. 
- Admin: add `getPlayableTrackIdsFromPlaylist` helper and reuse it in `createPlaylistMixFromDefinition` and `startSelectedPlaylistPlayback`, move mix activation after playable-track validation, change `playlistCycleInput` enablement logic to `!hasSelectedPlaylist && !hasMixTracks`, and ensure deleting an active playlist clears its playback mix and order.

### Testing
- Ran syntax/type checks: `node --check public/viewer.js && node --check public/admin.js`, which completed successfully. 
- Basic runtime sanity: updated files were lint/checked and changes were committed without runtime parse errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d67eb2f8bc83268588f6cd032686ff)